### PR TITLE
Compatibility check + loldrivers API

### DIFF
--- a/Vuln-Driver-Scanner.py
+++ b/Vuln-Driver-Scanner.py
@@ -47,8 +47,8 @@ def lol_vulnerable_driver_parser(data):
         for tag in tag_list:
             if tag.endswith('.sys'):
                 driver_list.append(tag[:-4])
-                samples = entry.get('KnownVulnerableSamples')
-                for sample in samples:
+                sample_list = entry.get('KnownVulnerableSamples')
+                for sample in sample_list:
                     sample_sha256 = sample.get('SHA256')
                     if sample_sha256:
                         hash_list.append(sample_sha256)

--- a/Vuln-Driver-Scanner.py
+++ b/Vuln-Driver-Scanner.py
@@ -129,10 +129,10 @@ def hash_host_drivers(command):
     except subprocess.CalledProcessError:
         pass
 
-def find_matches(driver_list_1, driver_list_2):
-    set1 = set(driver_list_1)
-    set2 = set(driver_list_2)
-    matches = list(set1.intersection(set2))
+def find_matches(vulnerable_drivers, host_drivers):
+    unique_vulnerable_drivers = set(vulnerable_drivers)
+    unique_host_drivers = set(host_drivers)
+    matches = list(unique_vulnerable_drivers.intersection(unique_host_drivers))
     return matches
 
 def os_compatability_check():
@@ -180,7 +180,7 @@ def main():
     os_compatability_check()
 
     try:
-        print(f'  \n  [+] Querying host drivers')
+        print(f'\n  [+] Querying host drivers')
         time.sleep(2)
 
         host_drivers = query_and_parse_host_drivers('driverquery /v')

--- a/Vuln-Driver-Scanner.py
+++ b/Vuln-Driver-Scanner.py
@@ -2,6 +2,7 @@ import subprocess
 import requests
 from requests.exceptions import ConnectionError, RequestException
 from bs4 import BeautifulSoup
+import os
 import time
 import sys
 import re
@@ -126,6 +127,13 @@ def find_matches(driver_list_1, driver_list_2):
     matches = list(set1.intersection(set2))
     return matches
 
+def os_compatability_check():
+    os_platform = sys.platform
+    os_name = os.name
+    if os_name != 'nt' or not os_platform.startswith('win'):
+        print(f'[-] Error! the OS name:{os_name} or OS type:{os_platform} does not appear to be windows')
+        exit(1)
+
 def display(matching_drivers):
 
     if len(matching_drivers):
@@ -161,6 +169,7 @@ def display(matching_drivers):
 def main():
     welcome()
     time.sleep(1)
+    os_compatability_check()
 
     try:
         print(f'  \n  [+] Querying host drivers')


### PR DESCRIPTION
`lol_vulnerable_driver_parser` didn't seem to work as intended. The matching to `driver.endswith('.sys')` did not seem to ever work correctly (always returned nothing) so I modified the code to use the loldrivers API instead (which also provides a lot more info than the web scrape).

Also added a check that the machine is a windows device and early exit in the case of incompatibility, seeing as it continued to attempt to work on my non-windows machine.

I don't have a Windows VM spun up currently to test so feel free to mess around with it before merging if you and something that doesn't work